### PR TITLE
Use the new server-side pagination of pyodata

### DIFF
--- a/examples/Swiss Parliament API.ipynb
+++ b/examples/Swiss Parliament API.ipynb
@@ -15,12 +15,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import swissparlpy\n",
+    "import swissparlpy as spp\n",
     "import requests\n",
     "import pandas as pd\n",
     "import os\n",
     "import urllib3\n",
-    "from datetime import datetime"
+    "from datetime import datetime, timezone"
    ]
   },
   {
@@ -54,7 +54,7 @@
    "source": [
     "session = requests.Session()\n",
     "session.verify = False # disable SSL verification\n",
-    "client = swissparlpy.SwissParlClient(session=session)"
+    "client = spp.SwissParlClient(session=session)"
    ]
   },
   {
@@ -74,8 +74,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import swissparlpy as spp\n",
-    "\n",
     "tables = spp.get_tables()\n",
     "glimpse_df = pd.DataFrame(spp.get_glimpse(tables[0]))\n",
     "glimpse_df"
@@ -196,11 +194,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "utc_start_date = datetime.fromisoformat('2019-10-01').astimezone(timezone.utc)\n",
+    "utc_end_Date = datetime.fromisoformat('2019-10-31').astimezone(timezone.utc)\n",
     "business_oct19 = client.get_data(\n",
     "    \"Business\",\n",
     "    Language=\"DE\",\n",
-    "    SubmissionDate__gte=datetime.fromisoformat('2019-10-01'),\n",
-    "    SubmissionDate__lt=datetime.fromisoformat('2019-10-31')\n",
+    "    SubmissionDate__gte=utc_start_date,\n",
+    "    SubmissionDate__lt=utc_end_Date\n",
     ")\n",
     "business_oct19.count"
    ]
@@ -295,11 +295,118 @@
     "df_voting50 = pd.concat([pd.read_pickle(os.path.join(path, x)) for x in os.listdir(path)])\n",
     "df_voting50"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9dc1854c-9f97-4bd4-bc21-50b361efa54b",
+   "metadata": {},
+   "source": [
+    "## Queries with lots of results (server-side pagination)\n",
+    "\n",
+    "There is a server-side limit of 1000 items that are being returned.\n",
+    "swissparlpy handles this server-side pagination transparently, so a user of the library should not worry about it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "408f6b47-c352-49ac-ac0a-b4fbaa00b7cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "business = client.get_data(\"Business\", Language = \"DE\")\n",
+    "business.count"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6b842d0-ebd5-44a2-9169-0d91128f3da3",
+   "metadata": {},
+   "source": [
+    "As we can see, there are over 50k results.\n",
+    "Initially only the first 1000 are loaded:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b463504-3a2e-417d-b302-47adb70d23a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(business.data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02717c13-01a6-4772-b492-c56afdddac85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "business[1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49fd8ec7-e5d8-4b10-ba03-1543bf52b81e",
+   "metadata": {},
+   "source": [
+    "But as soon as a next element is accessed, new data is (lazy) loaded:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fafc6266-cc43-4975-9e39-2866f29ef713",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "business[1001]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54556cc8-e076-4ea7-bb10-63aaf9f80e10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(business.data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19628322-4a7f-4720-a910-e2d72c1d744c",
+   "metadata": {},
+   "source": [
+    "If the last element is needed, all the data is loaded (NOTE: this uses quite some memory):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bcdb29ce-30ba-428c-9162-b2c843020227",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "business[-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79adb078-dffc-46a2-8746-2b54238b3718",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(business.data)"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -313,7 +420,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/examples/pagination.py
+++ b/examples/pagination.py
@@ -1,0 +1,12 @@
+import swissparlpy
+from pprint import pprint
+
+
+business = swissparlpy.get_data("Business", Language="DE")
+
+print(f"Count: {business.count})")
+print(f"Internal data: {len(business.data)}")
+
+pprint(business)
+pprint(business[1])
+pprint(business[1001])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = ["License :: OSI Approved :: MIT License"]
 dynamic = ["version", "description"]
 dependencies = [
     "requests",
-    "pyodata>=1.9.0",
+    "pyodata>=1.10.0",
 ]
 
 [project.optional-dependencies]

--- a/swissparlpy/client.py
+++ b/swissparlpy/client.py
@@ -1,5 +1,7 @@
+import warnings
 import requests
 import pyodata
+from . import errors
 
 SERVICE_URL = 'https://ws.parlament.ch/odata.svc/'
 
@@ -58,36 +60,87 @@ class SwissParlClient(object):
 
 class SwissParlResponse(object):
     def __init__(self, entity_request, variables):
-        self.entities = entity_request.execute()
-        self.count = self.entities.total_count
         self.variables = variables
-
         self.data = []
-        self._setup_proxies()
+        self.entity_request = entity_request
+        entities = self.load()
+        self._parse_data(entities)
 
-    def _setup_proxies(self):
-        for e in self.entities:
-            row = {k: SwissParlDataProxy(e, k) for k in self.variables}
-            self.data.append(row)
+    def load(self, next_url=None):
+        if next_url:
+            entities = self.entity_request.next_url(next_url).execute()
+        else:
+            entities = self.entity_request.execute()
+
+        return entities
+
+    def _load_new_data_until(self, limit):
+        if limit >= 10000:
+            warnings.warn(
+		f"""
+                More than 10'000 items are loaded, this will use a lot of memory.
+                Consider to query a subset of the data to improve performance.
+		""",
+		errors.ResultVeryLargeWarning,
+	    )
+        while limit >= len(self.data):
+            try:
+                self._load_new_data()
+            except errors.NoMoreRecordsError:
+                break
+
+    def _load_new_data(self):
+        if self.next_url is None:
+            raise errors.NoMoreRecordsError()
+        entities = self.load(next_url=self.next_url)
+        self._parse_data(entities)
+
+    def _parse_data(self, entities):
+        self.count = entities.total_count
+        self._setup_proxies(entities)
+        self.next_url = entities.next_url
+            
+    def _setup_proxies(self, entities):
+        for e in entities:
+            self.data.append(SwissParlDataProxy(e))
 
     def __len__(self):
         return self.count
 
     def __iter__(self):
-        for row in self.data:
-            yield {k: v() for k, v in row.items()}
+        # use while loop since self.data could grow while iterating
+        i = 0
+        while True:
+            # load new data when near end
+            if i == len(self.data):
+                try:
+                    self._load_new_data()
+                except errors.NoMoreRecordsError:
+                    break
+            yield {k: self.data[i](k) for k in self.variables}
+            i += 1
 
     def __getitem__(self, key):
-        items = self.data[key]
         if isinstance(key, slice):
-            return [{k: v() for k, v in i.items()} for i in items]
-        return {k: v() for k, v in items.items()}
+            limit = max(key.start or 0, key.stop or self.count)
+            self._load_new_data_until(limit)
+            count = len(self.data)
+            return [{k: self.data[i](k) for k in self.variables} for i in range(*key.indices(count))]
+
+        if not isinstance(key, int):
+            raise TypeError("Index must be an integer or slice")
+
+        limit = key
+        if limit < 0:
+            # if we get a negative index, load all data
+            limit = self.count
+        self._load_new_data_until(limit)
+        return {k: self.data[key](k) for k in self.variables}
 
 
 class SwissParlDataProxy(object):
-    def __init__(self, proxy, attribute):
+    def __init__(self, proxy):
         self.proxy = proxy
-        self.attribute = attribute
 
-    def __call__(self):
-        return getattr(self.proxy, self.attribute)
+    def __call__(self, attribute):
+        return getattr(self.proxy, attribute)

--- a/swissparlpy/errors.py
+++ b/swissparlpy/errors.py
@@ -2,3 +2,22 @@ class SwissParlError(Exception):
     """
     General SwissParl error class to provide a superclass for all other errors
     """
+
+
+class NoMoreRecordsError(SwissParlError):
+    """
+    Error to indicate, that there are no more records in the result.
+    """
+
+
+class SwissParlWarning(Warning):
+    """
+    General SwissParl warning class to provide a superclass for all warnings
+    """
+
+
+class ResultVeryLargeWarning(SwissParlWarning):
+    """
+    A warning to indicate, that a result is very large.
+    The query should be split up to reduce memory usage.
+    """


### PR DESCRIPTION
pyodata now support server-side pagination, so larger results can be queried directly by this library.

The result is lazy loaded when iterating over the response. But still note, that large results may use a lot of memory. To make developers aware of this, I introduced a warning when large results are loaded.